### PR TITLE
Update playground generation installation instructions

### DIFF
--- a/GENERATE.markdown
+++ b/GENERATE.markdown
@@ -7,7 +7,7 @@ Once:
 
 ```bash
 brew install node
-npm install -g swift-playground-builder
+npm install -g playground
 ```
 
 every time:

--- a/README.markdown
+++ b/README.markdown
@@ -955,6 +955,6 @@ names
 Info
 ====
 
-🍺 Playground generated with: [Swift Playground Builder](https://github.com/jas/swift-playground-builder) by [@jasonsandmeyer](http://twitter.com/jasonsandmeyer)
+🍺 Playground generated with: [playground](https://github.com/jas/playground) by [@jasonsandmeyer](http://twitter.com/jasonsandmeyer)
 
 🚀 How to generate playground (+zip) from this README: [GENERATE.markdown](https://github.com/ochococo/Design-Patterns-In-Swift/blob/master/GENERATE.markdown)

--- a/generate-playground.sh
+++ b/generate-playground.sh
@@ -5,4 +5,4 @@ playground ./README.markdown -p ios -s ./stylesheet.css && mv ./README.playgroun
 # no playground?
 #
 # brew install node
-# npm install -g swift-playground-builder
+# npm install -g playground


### PR DESCRIPTION
@ochococo Thanks for the mention!

Since I was able to secure the `playground` name on the npm registry, I've renamed the package and GitHub repo to be more in line with the name of the command.

https://www.npmjs.org/package/playground
