### PR TITLE
Fix markdown space on title

### DIFF
--- a/README.md
+++ b/README.md
@@ -450,8 +450,7 @@ enum CheckPoint {
     }
 }
 ```
-
- ### Usage
+### Usage
 
 ```swift
 


### PR DESCRIPTION
`### Usage` was not being correctly rendered
