### PR TITLE
Fix Prototype-Pattern SampleCode

### DIFF
--- a/Design-Patterns-CN.playground/Pages/Creational.xcplaygroundpage/Contents.swift
+++ b/Design-Patterns-CN.playground/Pages/Creational.xcplaygroundpage/Contents.swift
@@ -236,7 +236,7 @@ let screenTitle: String = Settings().currentTheme == .old ? "Itunes Connect" : "
 
 ### 示例：
 */
-struct MoonWorker {
+class MoonWorker {
 
     let name: String
     var health: Int = 100

--- a/Design-Patterns.playground/Pages/Creational.xcplaygroundpage/Contents.swift
+++ b/Design-Patterns.playground/Pages/Creational.xcplaygroundpage/Contents.swift
@@ -241,7 +241,7 @@ This practise is particularly useful when the construction of a new object is in
 
 ### Example
 */
-struct MoonWorker {
+class MoonWorker {
 
     let name: String
     var health: Int = 100

--- a/Design-Patterns.playground/Pages/Creational.xcplaygroundpage/timeline.xctimeline
+++ b/Design-Patterns.playground/Pages/Creational.xcplaygroundpage/timeline.xctimeline
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<Timeline
-   version = "3.0">
-   <TimelineItems>
-   </TimelineItems>
-</Timeline>

--- a/README-CN.md
+++ b/README-CN.md
@@ -1054,7 +1054,7 @@ let screenTitle: String = Settings().currentTheme == .old ? "Itunes Connect" : "
 ### 示例：
 
 ```swift
-struct MoonWorker {
+class MoonWorker {
 
     let name: String
     var health: Int = 100

--- a/README.md
+++ b/README.md
@@ -1058,7 +1058,7 @@ This practise is particularly useful when the construction of a new object is in
 ### Example
 
 ```swift
-struct MoonWorker {
+class MoonWorker {
 
     let name: String
     var health: Int = 100

--- a/source-cn/creational/prototype.swift
+++ b/source-cn/creational/prototype.swift
@@ -6,7 +6,7 @@
 
 ### 示例：
 */
-struct MoonWorker {
+class MoonWorker {
 
     let name: String
     var health: Int = 100

--- a/source/creational/prototype.swift
+++ b/source/creational/prototype.swift
@@ -7,7 +7,7 @@ This practise is particularly useful when the construction of a new object is in
 
 ### Example
 */
-struct MoonWorker {
+class MoonWorker {
 
     let name: String
     var health: Int = 100


### PR DESCRIPTION
I want to modify the prototype pattern sample code.
By default, the structure thinks that it does not need to use a prototype pattern because the values are copied.
The sample code is structured, so I think it is right to change it to a class.

- [x] Read [CONTRIBUTING.md]](https://github.com/ochococo/Design-Patterns-In-Swift/blob/master/CONTRIBUTING.md])
- [x] Added description
- [x] Linked to and/or created issue