### PR TITLE
Fix GENERATE.md link broken issue and add CONTRIBUTING-CN.md for Chinese relevant contributors

### DIFF
--- a/CONTRIBUTING-CN.md
+++ b/CONTRIBUTING-CN.md
@@ -1,0 +1,19 @@
+如何贡献(中文版)？
+==================
+
+-  你很棒！
+-  仅建议编辑`source-cn`目录中的文件，其余内容是自动生成的并已翻译
+-  提交更改
+-  本地运行`generate-playground-cn.sh`
+-  本地打开`Design-Patterns-CN.playground`文件并检查是否正常运行
+-  删除`generate-playground.sh`引起的更改，不要提交它！（_这是最近的更改_）
+-  请耐心尊重其他贡献者
+
+分支说明
+==================
+
+英文原上游主仓库已与中文版[统一维护](https://github.com/ochococo/Design-Patterns-In-Swift/pull/93)：
+- master 为主维护分支
+- chinese 分支仅为方便展示，将 README.md 显示为中文版本，由 GitHub Action 自动驱动
+
+因此，直接将 PR 提交至[原始仓库](https://github.com/ochococo/Design-Patterns-In-Swift) master 主分支即可。

--- a/source-cn/Index/header.md
+++ b/source-cn/Index/header.md
@@ -7,3 +7,8 @@
 👷 源项目由 [@nsmeme](http://twitter.com/nsmeme) (Oktawian Chojnacki) 维护。
 
 🇨🇳 中文版由 [@binglogo](https://twitter.com/binglogo) 整理翻译。
+
+🚀 如何由源代码，并生成 README 与 Playground 产物，请查看：
+- [CONTRIBUTING.md](https://github.com/ochococo/Design-Patterns-In-Swift/blob/master/CONTRIBUTING.md)
+- [CONTRIBUTING-CN.md](https://github.com/ochococo/Design-Patterns-In-Swift/blob/master/CONTRIBUTING-CN.md)
+

--- a/source/Index/header.md
+++ b/source/Index/header.md
@@ -10,4 +10,4 @@ A short cheat-sheet with Xcode 10.2 Playground ([Design-Patterns.playground.zip]
 
 👷 中文版由 [@binglogo](https://twitter.com/binglogo) (棒棒彬) 整理翻译。
 
-🚀 How to generate README, Playground and zip from source: [GENERATE.md](https://github.com/ochococo/Design-Patterns-In-Swift/blob/master/GENERATE.md)
+🚀 How to generate README, Playground and zip from source: [CONTRIBUTING.md](https://github.com/ochococo/Design-Patterns-In-Swift/blob/master/CONTRIBUTING.md)


### PR DESCRIPTION
- [x] Read [CONTRIBUTING.md](https://github.com/ochococo/Design-Patterns-In-Swift/blob/master/CONTRIBUTING.md])
- [x] Only edited files inside `source` folder (IMPORTANT) and commited them with a meaningful message
- [x] Ran `generate-playground.sh`, no errors
- [x] Opened playground, it worked fine
- [x] Did not commit the changes caused by `generate-playground.sh`
- [x] Linked to and/or created issue
- [x] Added a description to PR

---

- link update: GENERATE.md -> CONTRIBUTING.md Fix #127 
- add CONTRIBUTING-CN.md: describe how to contribute to Chinese translation and relevant branch descriptions.